### PR TITLE
Handle null password and improve logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,9 +40,12 @@ async function main() {
 		}[key];
 
 		const validationResult = validationFunction(value);
-		if (value && validationResult !== true) {
-			console.error(`Error in environment variable ${key}: ${validationResult}`);
-			return;
+		if (validationResult !== true) {
+			console.error(
+				"lido-withdrawals-automation failed.",
+				`Error in environment variable ${key}: ${validationResult}`
+			);
+			process.exit(1);
 		}
 	}
 
@@ -164,6 +167,7 @@ async function main() {
 	);
 
 	console.log("\n");
+	console.log(`lido-withdrawals-automation completed successfully.`);
 
 }
 
@@ -171,6 +175,6 @@ main();
 
 // Cath all unhanded exceptions
 process.on("unhandledRejection", (error) => {
-	console.error(error.message);
+	console.error("lido-withdrawals-automation failed. Error:", error.message);
 	process.exit(1);
 });

--- a/src/utils/validations.js
+++ b/src/utils/validations.js
@@ -38,7 +38,7 @@ function operatorIdValidation(value) {
 }
 
 function passwordValidation(value) {
-	return value.trim() !== "" ? true : "The password cannot be empty.";
+	return (value ?? '').trim() !== "" ? true : "The password cannot be empty.";
 }
 
 function moduleIdValidation(value) {


### PR DESCRIPTION
Improving error reporting in the case of:
* automation success/fail => The status is now printed `lido-withdrawals-automation failed.` or `lido-withdrawals-automation completed successfully.`;
* missing password => now `The password cannot be empty.` is printed, instead of `Cannot read properties of undefined (reading 'trim')`.