### PR TITLE
feat: support multiple staking modules and operators via WITHDRAWALS_SCOPE

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,20 @@
 # .env Example
-PERCENTAGE=10
 KAPI_URL=https://example.com/kapi
 REMOTE_SIGNER_URL=https://example.com/remote-signer
 PASSWORD=""
 OUTPUT_FOLDER=/path/to/your/output-folder
-OPERATOR_ID=
 BEACON_NODE_URL=http://localhost:5052
-MODULE_ID=1
 MISSING_KEYS_TOLERANCE=0
+
+# Multi-module / multi-operator scope (recommended).
+# JSON object: key = staking module ID, value = array of { id, percent } operators.
+#   - id: operator ID, integer >= 0 (0 is allowed).
+#   - percent: percentage of validators to withdraw for that operator, integer 1-100.
+WITHDRAWALS_SCOPE={"1":[{"id":123,"percent":50}],"4":[{"id":0,"percent":10},{"id":1,"percent":10}]}
+
+# DEPRECATED: MODULE_ID, OPERATOR_ID and PERCENTAGE still work (with a warning) but
+# will be removed in a future version. Do NOT set them together with WITHDRAWALS_SCOPE
+# (the tool will exit with an error). Use them only as a single-pair fallback.
+# MODULE_ID=1
+# OPERATOR_ID=123
+# PERCENTAGE=10

--- a/README.md
+++ b/README.md
@@ -48,30 +48,45 @@ npm install
 Create a `.env` file in the project root folder and set the following environment variables:
 
 ```
-PERCENTAGE=<percentage_of_validators_to_withdraw>
+WITHDRAWALS_SCOPE=<modules_to_operators_mapping>
 KAPI_URL=<kapi_endpoint_url>
 REMOTE_SIGNER_URL=<remote_signer_url>
 PASSWORD=<password_to_encrypt_signed_messages>
 OUTPUT_FOLDER=<path_to_output_folder>
-OPERATOR_ID=<operator_id>
 BEACON_NODE_URL=<beacon_node_url>
-MODULE_ID=<module_id>
 MISSING_KEYS_TOLERANCE=<missing_keys_tolerance>
 ```
 
 Replace the placeholders with your actual values. For example:
 
 ```
-PERCENTAGE=10
+WITHDRAWALS_SCOPE={"1":[{"id":123,"percent":50}],"4":[{"id":0,"percent":10},{"id":1,"percent":10}]}
 KAPI_URL=https://example.com/kapi
 REMOTE_SIGNER_URL=https://remotesigner.local:8080
 PASSWORD=mysecretpassword
 OUTPUT_FOLDER=/path/to/your/output-folder
-OPERATOR_ID=123
 BEACON_NODE_URL=http://localhost:5052
-MODULE_ID=1
 MISSING_KEYS_TOLERANCE=0
 ```
+
+### `WITHDRAWALS_SCOPE`
+
+`WITHDRAWALS_SCOPE` lets you process several staking modules and operators in a single run. It is a JSON object where:
+
+- The **key** is the staking module ID.
+- The **value** is a non-empty array of operators, each one an object with:
+  - `id`: the operator ID, an integer `>= 0` (`0` is allowed).
+  - `percent`: the percentage of that operator's validators to withdraw, an integer between `1` and `100`.
+
+Each module/operator pair is fetched from the KAPI independently with its own `percent`, so `WITHDRAWALS_SCOPE={"1":[{"id":123,"percent":50}],"4":[{"id":0,"percent":10}]}` withdraws 50% of operator 123 in module 1 and 10% of operator 0 in module 4.
+
+`MISSING_KEYS_TOLERANCE` is global and applied per pair. The output stays flat in `OUTPUT_FOLDER` (file names are unchanged). Signatures are encrypted once at the end, so if any pair fails the whole process aborts without writing partial output.
+
+### Deprecated variables
+
+`MODULE_ID`, `OPERATOR_ID` and `PERCENTAGE` are deprecated and will be removed in a future version. They still work as a single-pair fallback: when all three are set (and `WITHDRAWALS_SCOPE` is not), the tool prints a deprecation warning and maps them internally to `{"<MODULE_ID>":[{"id":<OPERATOR_ID>,"percent":<PERCENTAGE>}]}`. Note the legacy `OPERATOR_ID` still requires a value `> 0`, while `WITHDRAWALS_SCOPE` allows operator `id` `0`.
+
+Setting `WITHDRAWALS_SCOPE` **together with** any of `MODULE_ID`/`OPERATOR_ID`/`PERCENTAGE` makes the tool exit with an error: use only one of the two approaches.
 
 ## Usage
 
@@ -81,7 +96,7 @@ Run the script using the following command:
 npm start
 ```
 
-The script will check the environment variables and prompt you for any missing values. After providing the required information, the script will fetch validator data, create withdrawal messages, sign them, encrypt the signed messages, and save them to the output folder.
+The script will check the environment variables and prompt you for any missing values. If neither `WITHDRAWALS_SCOPE` nor the deprecated trio is set, the interactive prompts ask for a single module ID, operator ID and percentage. After providing the required information, the script will fetch validator data, create withdrawal messages, sign them, encrypt the signed messages, and save them to the output folder.
 
 ## Contributing
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const inquirer = require("inquirer").default;
-const { percentageValidation, passwordValidation, outputFolderValidation, operatorIdValidation, urlValidation, moduleIdValidation, missingKeysToleranceValidation, booleanValidation } = require("./src/utils/validations");
+const { percentageValidation, passwordValidation, outputFolderValidation, operatorIdValidation, urlValidation, moduleIdValidation, missingKeysToleranceValidation, booleanValidation, withdrawalsScopeValidation } = require("./src/utils/validations");
+const { resolveScope, buildScopeFromSinglePair, expandScope } = require("./src/utils/scope");
 const { fetchValidatorsData } = require("./src/withdrawal/fetchValidatorsData");
 const { signWithdrawalMessages } = require("./src/withdrawal/signWithdrawalMessages");
 const { encryptMessages } = require("./src/withdrawal/encryptMessages");
@@ -10,7 +11,7 @@ require("dotenv").config();
 async function main() {
 
 	console.log("\n");
-	console.info("🚀 Lido Withdrawals Automation developed by Stakely.io - v1.3.0");
+	console.info("🚀 Lido Withdrawals Automation developed by Stakely.io - v1.4.0");
 	console.log("\n");
 	console.info("Step 1: Checking environment variables and asking for missing values...");
 
@@ -24,6 +25,7 @@ async function main() {
 		operatorId: process.env.OPERATOR_ID,
 		beaconNodeUrl: process.env.BEACON_NODE_URL,
 		moduleId: process.env.MODULE_ID,
+		withdrawalsScope: process.env.WITHDRAWALS_SCOPE,
 		missingKeysTolerance: process.env.MISSING_KEYS_TOLERANCE,
 		useCurrentForkVersion: process.env.USE_CURRENT_FORK_VERSION,
 	};
@@ -45,6 +47,7 @@ async function main() {
 			operatorId: operatorIdValidation,
 			beaconNodeUrl: urlValidation,
 			moduleId: moduleIdValidation,
+			withdrawalsScope: withdrawalsScopeValidation,
 			missingKeysTolerance: missingKeysToleranceValidation,
 			useCurrentForkVersion: booleanValidation,
 		}[key];
@@ -59,17 +62,18 @@ async function main() {
 		}
 	}
 
+	// Resolve the withdrawals scope from the environment variables.
+	// Returns null when there is not enough information and we must ask for a
+	// single module/operator/percentage interactively.
+	let scope = resolveScope({
+		withdrawalsScope: env.withdrawalsScope,
+		moduleId: env.moduleId,
+		operatorId: env.operatorId,
+		percentage: env.percentage,
+	});
+
 	// Ask for missing values
 	const questions = [];
-
-	if (!env.percentage) {
-		questions.push({
-			type: "input",
-			name: "percentage",
-			message: "Please enter the percentage of validators (1 to 100):",
-			validate: percentageValidation,
-		});
-	}
 
 	if (!env.kapiUrl) {
 		questions.push({
@@ -107,15 +111,6 @@ async function main() {
 		});
 	}
 
-	if (!env.operatorId) {
-		questions.push({
-			type: "input",
-			name: "operatorId",
-			message: "Please enter the operator ID:",
-			validate: operatorIdValidation,
-		});
-	}
-
 	if (!env.beaconNodeUrl) {
 		questions.push({
 			type: "input",
@@ -125,57 +120,90 @@ async function main() {
 		});
 	}
 
-	if (!env.moduleId) {
+	// If no scope could be resolved from the environment, ask for a single
+	// module/operator/percentage and build a one-pair scope from the answers.
+	if (scope === null) {
 		questions.push({
 			type: "input",
 			name: "moduleId",
 			message: "Please enter the module ID:",
 			validate: moduleIdValidation,
 		});
+		questions.push({
+			type: "input",
+			name: "operatorId",
+			message: "Please enter the operator ID:",
+			validate: operatorIdValidation,
+		});
+		questions.push({
+			type: "input",
+			name: "percentage",
+			message: "Please enter the percentage of validators (1 to 100):",
+			validate: percentageValidation,
+		});
 	}
 
 	const answers = await inquirer.prompt(questions);
 
+	if (scope === null) {
+		scope = buildScopeFromSinglePair(answers.moduleId, answers.operatorId, answers.percentage);
+	}
+
 	// Combine environment variables and answers or default values.
 	const params = {
-		percentage: env.percentage || answers.percentage,
 		kapiUrl: env.kapiUrl || answers.kapiUrl,
 		remoteSignerUrl: env.remoteSignerUrl || answers.remoteSignerUrl,
 		password: env.password || answers.password,
-		operatorId: env.operatorId || answers.operatorId,
 		outputFolder: env.outputFolder || answers.outputFolder,
 		beaconNodeUrl: env.beaconNodeUrl || answers.beaconNodeUrl,
-		moduleId: env.moduleId || answers.moduleId,
 		missingKeysTolerance: env.missingKeysTolerance || 0,
 		useCurrentForkVersion: env.useCurrentForkVersion === "true",
 	};
 
-	// Get validators data from Kapi
-	console.log("Step 2: Fetching validators data from Kapi...");
+	// Expand the scope into the list of (module, operator, percent) pairs to process.
+	const pairs = expandScope(scope);
 
-	const kapiJsonResponse = await fetchValidatorsData(
-		params.kapiUrl, // Kapi URL
-		params.moduleId, // Module ID
-		params.operatorId, // Operator ID
-		params.percentage // Percentage of validators
-	);
+	// Process every pair (fetch + sign). Signatures are accumulated and encrypted
+	// once at the end, so if any pair fails the whole process aborts without
+	// writing partial output.
+	const allSignatures = [];
+	let pairIndex = 0;
 
-	console.log("Step 3: Creating the withdrawal messages and signing them with the remote signer...");
+	for (const { moduleId, operatorId, percent } of pairs) {
+		pairIndex++;
+		console.log("\n");
+		console.log(`================= [ PAIR ${pairIndex}/${pairs.length} ] =================`);
+		console.log(`Module: ${moduleId}   Operator Id: ${operatorId}   Percent: ${percent}%`);
 
-	const signatures = await signWithdrawalMessages(
-		kapiJsonResponse.data, // Validators data (public keys)
-		kapiJsonResponse.meta.clBlockSnapshot.epoch, // Epoch from Kapi
-		params.remoteSignerUrl, // Remote signer URL
-		params.beaconNodeUrl, // Beacon node URL
-		params.missingKeysTolerance, // Missing keys tolerance
-		params.useCurrentForkVersion // Use current fork version instead of Capella
-	);
+		// Get validators data from Kapi
+		console.log("Step 2: Fetching validators data from Kapi...");
+
+		const kapiJsonResponse = await fetchValidatorsData(
+			params.kapiUrl, // Kapi URL
+			moduleId, // Module ID
+			operatorId, // Operator ID
+			percent // Percentage of validators for this operator
+		);
+
+		console.log("Step 3: Creating the withdrawal messages and signing them with the remote signer...");
+
+		const signatures = await signWithdrawalMessages(
+			kapiJsonResponse.data, // Validators data (public keys)
+			kapiJsonResponse.meta.clBlockSnapshot.epoch, // Epoch from Kapi
+			params.remoteSignerUrl, // Remote signer URL
+			params.beaconNodeUrl, // Beacon node URL
+			params.missingKeysTolerance, // Missing keys tolerance
+			params.useCurrentForkVersion // Use current fork version instead of Capella
+		);
+
+		allSignatures.push(...signatures);
+	}
 
 	console.log("\n");
 	console.log("Step 4: Encrypt the signed messages with the password file and save them to the output folder...");
 
 	await encryptMessages(
-		signatures, // Signed messages
+		allSignatures, // Signed messages from every pair
 		params.outputFolder, // Output folder
 		params.password, // File with the password
 	);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lido-withdrawals-automation",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Lido Withdrawals Automation is a command-line tool that assists with the LIDO validators withdrawal process. The tool streamlines the procedure by fetching validators data, generating withdrawal messages, signing them with a remote signer, encrypting the signed messages, and saving them to the output folder.",
   "main": "index.js",
   "scripts": {

--- a/src/utils/scope.js
+++ b/src/utils/scope.js
@@ -1,0 +1,73 @@
+const DEPRECATION_WARNING =
+	"⚠️  DEPRECATION WARNING: MODULE_ID, OPERATOR_ID and PERCENTAGE are deprecated and will be removed in a future version. " +
+	"Please migrate to WITHDRAWALS_SCOPE (e.g. WITHDRAWALS_SCOPE='{\"1\":[{\"id\":123,\"percent\":50}]}').";
+
+// Builds a scope object from a single module/operator/percent triple.
+// Used by the deprecated legacy variables and by the interactive flow.
+function buildScopeFromSinglePair(moduleId, operatorId, percent) {
+	return {
+		[moduleId]: [
+			{
+				id: Number(operatorId),
+				percent: Number(percent),
+			},
+		],
+	};
+}
+
+// Resolves the withdrawals scope from the environment variables.
+// Returns a scope object, or null when there is not enough information and the
+// interactive prompts must complete the data. Throws when the new and the
+// deprecated variables are combined.
+function resolveScope({ withdrawalsScope, moduleId, operatorId, percentage }) {
+	const usesLegacy = moduleId !== undefined || operatorId !== undefined || percentage !== undefined;
+
+	if (withdrawalsScope !== undefined) {
+		if (usesLegacy) {
+			throw new Error(
+				"WITHDRAWALS_SCOPE cannot be combined with the deprecated MODULE_ID/OPERATOR_ID/PERCENTAGE variables. Use only WITHDRAWALS_SCOPE."
+			);
+		}
+		return JSON.parse(withdrawalsScope);
+	}
+
+	// No new scope: fall back to the deprecated variables only when all three are present.
+	if (moduleId !== undefined && operatorId !== undefined && percentage !== undefined) {
+		console.warn(DEPRECATION_WARNING);
+		return buildScopeFromSinglePair(moduleId, operatorId, percentage);
+	}
+
+	// Not enough information: the caller will gather it interactively.
+	return null;
+}
+
+// Flattens a scope object into the list of (module, operator, percent) pairs to
+// process. Deduplicates identical (moduleId, operatorId) pairs keeping the first
+// occurrence (the validation already blocks duplicates with a different percent).
+function expandScope(scope) {
+	const pairs = [];
+	const seen = new Set();
+
+	for (const [moduleId, operators] of Object.entries(scope)) {
+		for (const operator of operators) {
+			const key = `${moduleId}/${operator.id}`;
+			if (seen.has(key)) {
+				continue;
+			}
+			seen.add(key);
+			pairs.push({
+				moduleId: moduleId,
+				operatorId: operator.id,
+				percent: operator.percent,
+			});
+		}
+	}
+
+	return pairs;
+}
+
+module.exports = {
+	resolveScope,
+	buildScopeFromSinglePair,
+	expandScope,
+};

--- a/src/utils/validations.js
+++ b/src/utils/validations.js
@@ -62,6 +62,57 @@ function booleanValidation(value) {
 	return value === "true" || value === "false" ? true : "Please enter a valid boolean value (true or false).";
 }
 
+function withdrawalsScopeValidation(value) {
+	let scope;
+	try {
+		scope = JSON.parse(value);
+	} catch (error) {
+		return "WITHDRAWALS_SCOPE is not valid JSON. Expected format: {\"1\":[{\"id\":123,\"percent\":50}]}.";
+	}
+
+	if (typeof scope !== "object" || scope === null || Array.isArray(scope)) {
+		return "WITHDRAWALS_SCOPE must be a JSON object mapping staking module IDs to operator arrays.";
+	}
+
+	const moduleIds = Object.keys(scope);
+	if (moduleIds.length === 0) {
+		return "WITHDRAWALS_SCOPE cannot be empty. Define at least one staking module with one operator.";
+	}
+
+	for (const moduleId of moduleIds) {
+		if (moduleIdValidation(moduleId) !== true) {
+			return "WITHDRAWALS_SCOPE staking module ID cannot be empty.";
+		}
+
+		const operators = scope[moduleId];
+		if (!Array.isArray(operators) || operators.length === 0) {
+			return `Module ${moduleId} must map to a non-empty array of operators.`;
+		}
+
+		const seenOperatorIds = new Set();
+		for (const operator of operators) {
+			if (typeof operator !== "object" || operator === null || Array.isArray(operator)) {
+				return `Each operator in module ${moduleId} must be an object with "id" and "percent".`;
+			}
+
+			if (!Number.isInteger(operator.id) || operator.id < 0) {
+				return `Operator id ${operator.id} in module ${moduleId} must be an integer greater than or equal to 0.`;
+			}
+
+			if (!Number.isInteger(operator.percent) || operator.percent < 1 || operator.percent > 100) {
+				return `percent ${operator.percent} for operator ${operator.id} in module ${moduleId} must be an integer between 1 and 100.`;
+			}
+
+			if (seenOperatorIds.has(operator.id)) {
+				return `Operator id ${operator.id} is duplicated in module ${moduleId}.`;
+			}
+			seenOperatorIds.add(operator.id);
+		}
+	}
+
+	return true;
+}
+
 // Export all validation functions
 module.exports = {
 	percentageValidation,
@@ -72,4 +123,5 @@ module.exports = {
 	moduleIdValidation,
 	missingKeysToleranceValidation,
 	booleanValidation,
+	withdrawalsScopeValidation,
 };

--- a/tests/scope.test.js
+++ b/tests/scope.test.js
@@ -1,0 +1,156 @@
+/* eslint-disable no-undef */
+const {
+	resolveScope,
+	buildScopeFromSinglePair,
+	expandScope,
+} = require("../src/utils/scope.js");
+
+describe("resolveScope", () => {
+	test("should parse WITHDRAWALS_SCOPE when no legacy variables are present", () => {
+		const scope = resolveScope({
+			withdrawalsScope: "{\"1\":[{\"id\":123,\"percent\":50}]}",
+			moduleId: undefined,
+			operatorId: undefined,
+			percentage: undefined,
+		});
+		expect(scope).toEqual({ "1": [{ id: 123, percent: 50 }] });
+	});
+
+	const VALID_SCOPE = "{\"1\":[{\"id\":123,\"percent\":50}]}";
+
+	test("should throw when WITHDRAWALS_SCOPE is combined with MODULE_ID", () => {
+		expect(() => resolveScope({
+			withdrawalsScope: VALID_SCOPE,
+			moduleId: "1",
+			operatorId: undefined,
+			percentage: undefined,
+		})).toThrow(/cannot be combined/);
+	});
+
+	test("should throw when WITHDRAWALS_SCOPE is combined with OPERATOR_ID", () => {
+		expect(() => resolveScope({
+			withdrawalsScope: VALID_SCOPE,
+			moduleId: undefined,
+			operatorId: "123",
+			percentage: undefined,
+		})).toThrow(/cannot be combined/);
+	});
+
+	test("should throw when WITHDRAWALS_SCOPE is combined with PERCENTAGE", () => {
+		expect(() => resolveScope({
+			withdrawalsScope: VALID_SCOPE,
+			moduleId: undefined,
+			operatorId: undefined,
+			percentage: "10",
+		})).toThrow(/cannot be combined/);
+	});
+
+	test("should throw when WITHDRAWALS_SCOPE is combined with the full legacy trio", () => {
+		expect(() => resolveScope({
+			withdrawalsScope: VALID_SCOPE,
+			moduleId: "1",
+			operatorId: "123",
+			percentage: "10",
+		})).toThrow(/cannot be combined/);
+	});
+
+	test("should not warn about deprecation when WITHDRAWALS_SCOPE is used", () => {
+		const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+		resolveScope({
+			withdrawalsScope: VALID_SCOPE,
+			moduleId: undefined,
+			operatorId: undefined,
+			percentage: undefined,
+		});
+		expect(warnSpy).not.toHaveBeenCalled();
+		warnSpy.mockRestore();
+	});
+
+	test("should map the deprecated trio to a scope and warn", () => {
+		const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+		const scope = resolveScope({
+			withdrawalsScope: undefined,
+			moduleId: "1",
+			operatorId: "123",
+			percentage: "50",
+		});
+
+		expect(scope).toEqual({ "1": [{ id: 123, percent: 50 }] });
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+
+		warnSpy.mockRestore();
+	});
+
+	test("should return null when the legacy trio is incomplete", () => {
+		// Only MODULE_ID
+		expect(resolveScope({
+			withdrawalsScope: undefined,
+			moduleId: "1",
+			operatorId: undefined,
+			percentage: undefined,
+		})).toBeNull();
+
+		// Only OPERATOR_ID
+		expect(resolveScope({
+			withdrawalsScope: undefined,
+			moduleId: undefined,
+			operatorId: "123",
+			percentage: undefined,
+		})).toBeNull();
+
+		// MODULE_ID + OPERATOR_ID but missing PERCENTAGE
+		expect(resolveScope({
+			withdrawalsScope: undefined,
+			moduleId: "1",
+			operatorId: "123",
+			percentage: undefined,
+		})).toBeNull();
+
+		// MODULE_ID + PERCENTAGE but missing OPERATOR_ID
+		expect(resolveScope({
+			withdrawalsScope: undefined,
+			moduleId: "1",
+			operatorId: undefined,
+			percentage: "50",
+		})).toBeNull();
+	});
+
+	test("should return null when nothing is provided", () => {
+		expect(resolveScope({
+			withdrawalsScope: undefined,
+			moduleId: undefined,
+			operatorId: undefined,
+			percentage: undefined,
+		})).toBeNull();
+	});
+});
+
+describe("buildScopeFromSinglePair", () => {
+	test("should build a single-pair scope with numeric id and percent", () => {
+		expect(buildScopeFromSinglePair("1", "123", "50")).toEqual({ "1": [{ id: 123, percent: 50 }] });
+	});
+});
+
+describe("expandScope", () => {
+	test("should flatten the scope into ordered pairs keeping operator 0", () => {
+		const scope = {
+			"1": [{ id: 123, percent: 50 }],
+			"4": [{ id: 0, percent: 10 }, { id: 1, percent: 20 }],
+		};
+		expect(expandScope(scope)).toEqual([
+			{ moduleId: "1", operatorId: 123, percent: 50 },
+			{ moduleId: "4", operatorId: 0, percent: 10 },
+			{ moduleId: "4", operatorId: 1, percent: 20 },
+		]);
+	});
+
+	test("should deduplicate identical module/operator pairs keeping the first occurrence", () => {
+		const scope = { "1": [{ id: 1, percent: 10 }, { id: 1, percent: 99 }] };
+		expect(expandScope(scope)).toEqual([{ moduleId: "1", operatorId: 1, percent: 10 }]);
+	});
+
+	test("should return an empty array for an empty scope", () => {
+		expect(expandScope({})).toEqual([]);
+	});
+});

--- a/tests/validations.test.js
+++ b/tests/validations.test.js
@@ -8,6 +8,7 @@ const {
 	passwordValidation,
 	moduleIdValidation,
 	missingKeysToleranceValidation,
+	withdrawalsScopeValidation,
 } = require("../src/utils/validations.js");
 
 jest.mock("fs");
@@ -101,5 +102,67 @@ describe("missingKeysToleranceValidation", () => {
 		expect(missingKeysToleranceValidation("abc")).toBe("Please enter a valid integer greater than or equal to 0 for the missing keys tolerance.");
 		expect(missingKeysToleranceValidation("1.5")).toBe("Please enter a valid integer greater than or equal to 0 for the missing keys tolerance.");
 		expect(missingKeysToleranceValidation("10.0")).toBe("Please enter a valid integer greater than or equal to 0 for the missing keys tolerance.");
+	});
+});
+
+describe("withdrawalsScopeValidation", () => {
+	test("should return true for a valid scope", () => {
+		expect(withdrawalsScopeValidation("{\"1\":[{\"id\":123,\"percent\":50}]}")).toBe(true);
+	});
+
+	test("should return true for multiple modules and operators", () => {
+		expect(withdrawalsScopeValidation("{\"1\":[{\"id\":123,\"percent\":50}],\"4\":[{\"id\":0,\"percent\":10},{\"id\":1,\"percent\":100}]}")).toBe(true);
+	});
+
+	test("should allow operator id 0", () => {
+		expect(withdrawalsScopeValidation("{\"1\":[{\"id\":0,\"percent\":10}]}")).toBe(true);
+	});
+
+	test("should return error message for invalid JSON", () => {
+		expect(withdrawalsScopeValidation("{\"1\":[")).toBe("WITHDRAWALS_SCOPE is not valid JSON. Expected format: {\"1\":[{\"id\":123,\"percent\":50}]}.");
+		expect(withdrawalsScopeValidation("not json")).toBe("WITHDRAWALS_SCOPE is not valid JSON. Expected format: {\"1\":[{\"id\":123,\"percent\":50}]}.");
+	});
+
+	test("should return error message when not a plain object", () => {
+		const error = "WITHDRAWALS_SCOPE must be a JSON object mapping staking module IDs to operator arrays.";
+		expect(withdrawalsScopeValidation("[1,2]")).toBe(error);
+		expect(withdrawalsScopeValidation("\"5\"")).toBe(error);
+		expect(withdrawalsScopeValidation("null")).toBe(error);
+	});
+
+	test("should return error message for an empty object", () => {
+		expect(withdrawalsScopeValidation("{}")).toBe("WITHDRAWALS_SCOPE cannot be empty. Define at least one staking module with one operator.");
+	});
+
+	test("should return error message for an empty module ID key", () => {
+		expect(withdrawalsScopeValidation("{\"\":[{\"id\":1,\"percent\":10}]}")).toBe("WITHDRAWALS_SCOPE staking module ID cannot be empty.");
+	});
+
+	test("should return error message when a module does not map to a non-empty array", () => {
+		expect(withdrawalsScopeValidation("{\"1\":5}")).toBe("Module 1 must map to a non-empty array of operators.");
+		expect(withdrawalsScopeValidation("{\"1\":[]}")).toBe("Module 1 must map to a non-empty array of operators.");
+	});
+
+	test("should return error message when an operator is not an object", () => {
+		expect(withdrawalsScopeValidation("{\"1\":[123]}")).toBe("Each operator in module 1 must be an object with \"id\" and \"percent\".");
+	});
+
+	test("should return error message for an invalid operator id", () => {
+		expect(withdrawalsScopeValidation("{\"1\":[{\"id\":1.5,\"percent\":10}]}")).toBe("Operator id 1.5 in module 1 must be an integer greater than or equal to 0.");
+		expect(withdrawalsScopeValidation("{\"1\":[{\"id\":-1,\"percent\":10}]}")).toBe("Operator id -1 in module 1 must be an integer greater than or equal to 0.");
+		expect(withdrawalsScopeValidation("{\"1\":[{\"id\":\"a\",\"percent\":10}]}")).toBe("Operator id a in module 1 must be an integer greater than or equal to 0.");
+		expect(withdrawalsScopeValidation("{\"1\":[{\"percent\":10}]}")).toBe("Operator id undefined in module 1 must be an integer greater than or equal to 0.");
+	});
+
+	test("should return error message for an invalid percent", () => {
+		expect(withdrawalsScopeValidation("{\"1\":[{\"id\":1,\"percent\":0}]}")).toBe("percent 0 for operator 1 in module 1 must be an integer between 1 and 100.");
+		expect(withdrawalsScopeValidation("{\"1\":[{\"id\":1,\"percent\":101}]}")).toBe("percent 101 for operator 1 in module 1 must be an integer between 1 and 100.");
+		expect(withdrawalsScopeValidation("{\"1\":[{\"id\":1,\"percent\":50.5}]}")).toBe("percent 50.5 for operator 1 in module 1 must be an integer between 1 and 100.");
+		expect(withdrawalsScopeValidation("{\"1\":[{\"id\":1,\"percent\":\"x\"}]}")).toBe("percent x for operator 1 in module 1 must be an integer between 1 and 100.");
+		expect(withdrawalsScopeValidation("{\"1\":[{\"id\":1}]}")).toBe("percent undefined for operator 1 in module 1 must be an integer between 1 and 100.");
+	});
+
+	test("should return error message for a duplicated operator id in a module", () => {
+		expect(withdrawalsScopeValidation("{\"1\":[{\"id\":1,\"percent\":10},{\"id\":1,\"percent\":20}]}")).toBe("Operator id 1 is duplicated in module 1.");
 	});
 });


### PR DESCRIPTION
Add WITHDRAWALS_SCOPE, a JSON mapping of staking module IDs to operators with a per-operator withdrawal percentage, e.g. {"1":[{"id":123,"percent":50}],"4":[{"id":0,"percent":10}]}.

Each module/operator pair is fetched and signed independently, and all signatures are encrypted once at the end (a failing pair aborts the run without writing partial output).

Deprecate MODULE_ID, OPERATOR_ID and PERCENTAGE: they still work togetheras a single-pair fallback (with a deprecation warning) but cannot be combined with WITHDRAWALS_SCOPE, which makes the tool exit on startup.

Interactive mode keeps asking for a single module/operator/percentage when no scope is configured.
- add withdrawalsScopeValidation in src/utils/validations.js
- add src/utils/scope.js (resolveScope, buildScopeFromSinglePair, expandScope)
- loop index.js over the expanded scope pairs
- add tests/scope.test.js and extend tests/validations.test.js
- update README and .env.example, bump version to 1.4.0